### PR TITLE
Visually appended post content preview to topic titles

### DIFF
--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -15,6 +15,22 @@ module.exports = function (Categories) {
 		let results = await plugins.hooks.fire('filter:category.topics.prepare', data);
 		const tids = await Categories.getTopicIds(results);
 		let topicsData = await topics.getTopicsByTids(tids, data.uid);
+		
+		let mainPosts = await topics.getMainPosts(tids, data.uid);
+		const strippedContent = mainPosts.map(post => {
+			// Strip HTML tags using regex
+			const plainText = post.content.replace(/<[^>]*>/g, '').trim();
+		
+			// Get first 10 chars
+			return plainText.substring(0, 10);
+		});
+		topicsData = topicsData.map((topic, index) => {
+			// Set titleRaw and title to stripped content corresp to same index
+			topic.titleRaw = topic.titleRaw + ": " + strippedContent[index] + "...";
+			topic.title = topic.title + ": " + strippedContent[index] + "...";
+			return topic;
+		});
+
 		topicsData = await user.blocks.filter(data.uid, topicsData);
 
 		if (!topicsData.length) {

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -15,19 +15,17 @@ module.exports = function (Categories) {
 		let results = await plugins.hooks.fire('filter:category.topics.prepare', data);
 		const tids = await Categories.getTopicIds(results);
 		let topicsData = await topics.getTopicsByTids(tids, data.uid);
-		
-		let mainPosts = await topics.getMainPosts(tids, data.uid);
-		const strippedContent = mainPosts.map(post => {
-			// Strip HTML tags using regex
+		// Call getMainPosts to retreive actual post content (content not available in topics)
+		const mainPosts = await topics.getMainPosts(tids, data.uid);
+		// Remove HTML tags and get first 10 characteres of content to preview
+		const strippedContent = mainPosts.map((post) => {
 			const plainText = post.content.replace(/<[^>]*>/g, '').trim();
-		
-			// Get first 10 chars
 			return plainText.substring(0, 10);
 		});
 		topicsData = topicsData.map((topic, index) => {
 			// Set titleRaw and title to stripped content corresp to same index
-			topic.titleRaw = topic.titleRaw + ": " + strippedContent[index] + "...";
-			topic.title = topic.title + ": " + strippedContent[index] + "...";
+			topic.titleRaw = `${topic.titleRaw}: ${strippedContent[index]}...`;
+			topic.title = `${topic.title}: ${strippedContent[index]}...`;
 			return topic;
 		});
 

--- a/src/groups/data.js
+++ b/src/groups/data.js
@@ -90,7 +90,6 @@ function modifyGroup(group, fields) {
 		db.parseIntFields(group, intFields, fields);
 		escapeGroupData(group);
 
-		console.log('MICHAEL LI');
 		setDefaultValues(group);
 
 		coverUrl(group, 'cover:url');


### PR DESCRIPTION
## What?
Edited each topic's title to append the first 10 characters of the post's content followed by "..." to display on NodeBB site within a category. Also deleted a forgotten print statement from P1

## Where?
Added code in `Categories.getCategoryTopics` function in `src/categories/topics.js` file. 

## Why?
Progress for issue #6  and User Story 1. Displays first few characters of post content before needing to click into the post.

## How?
Obtained post content by calling `getMainPosts` function– `topicsData` object does not have any field containing the actual post content needed. However, `topicsData` does have title and titleRaw fields. For each of these two fields, I remapped them to their original string values with the post content appended.

## Testing?
Have not tested yet. I am concerend about this appending of post content preview going over some maximumTitleLength value? Also this was more of a front end change, I am worried about this simple re-mapping not fully being altered in the backend and breaking other functions. Some github tests were failed as well:

## Screenshots
 
<img width="936" alt="Screenshot 2024-09-18 at 5 07 49 PM" src="https://github.com/user-attachments/assets/52f55833-aa78-4f66-89e3-896beb0fd010">


![screenshot_2024-09-18_at_4 49 16___pm_720](https://github.com/user-attachments/assets/ef29341b-3f1c-4952-b5fe-0d2533e78450)
